### PR TITLE
Upgrade: to zio 2.0.0 and minor upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-scalaVersion := "2.13.8"
+scalaVersion := "3.1.3"
 organization := "dev.zio"
 name := "zio-quickstart-hello-world"
 
-libraryDependencies += "dev.zio" %% "zio" % "2.0.0-RC6" 
+libraryDependencies += "dev.zio" %% "zio" % "2.0.0" 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.7.1

--- a/src/main/scala/dev/zio/quickstart/MainApp.scala
+++ b/src/main/scala/dev/zio/quickstart/MainApp.scala
@@ -1,6 +1,6 @@
 package dev.zio.quickstart
 
-import zio._
+import zio.*
 
 object MainApp extends ZIOAppDefault {
   def run = Console.printLine("Hello, World!")


### PR DESCRIPTION
Zio from `2.0.0-RC6` to `2.0.0`
Scala from `2.13.8` to `3.1.3`
Sbt from `1.6.2` to `1.7.1`
replace `_`  by `*` for imports 
