### PR TITLE
Fix .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,2 @@
-version = 3.5.3
+version = 3.5.8
+runner.dialect = scala3


### PR DESCRIPTION
Without this fix, `scalafmt` of version `3.5.8` (and supposedly newer) produces an error:

```
Invalid config: Default dialect is deprecated; use explicit: [sbt0137,sbt1,scala211,scala212,scala212source3,scala213,scala213source3,scala3]
Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
```

This leads to formatting being broken via both the `scalafmt` CLI and the editor plugin.